### PR TITLE
Fix X display descriptor leak

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,12 @@ impl XHandle {
     }
 }
 
+impl Drop for XHandle {
+    fn drop(&mut self) {
+        unsafe { xlib::XCloseDisplay(self.sys.as_ptr()); }
+    }
+}
+
 #[derive(Debug)]
 pub struct Monitor {
     pub name: String,


### PR DESCRIPTION
Got out XOpenDisplay error after creating/destoying XHandle multiple times. So X Display handle should be closed on XHandle destroy.