### PR TITLE
add "serialize" feature to optionally derive Serialize and Deserialize for structs. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ categories = ["os::linux-apis", "api-bindings"]
 thiserror = "1.0.24"
 x11 = { version = "2.18.2", features = ["xlib", "xrandr"] }
 indexmap = "1.6.2"
+serde = {version = "1.0.133", features=["derive"], optional=true}
+
+[features]
+serialize = ["serde", "indexmap/serde-1"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,8 @@ use std::os::raw::c_ulong;
 use std::{ptr, slice};
 
 pub use indexmap;
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use x11::{xlib, xrandr};
 
@@ -177,11 +179,14 @@ impl XHandle {
 
 impl Drop for XHandle {
     fn drop(&mut self) {
-        unsafe { xlib::XCloseDisplay(self.sys.as_ptr()); }
+        unsafe {
+            xlib::XCloseDisplay(self.sys.as_ptr());
+        }
     }
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Monitor {
     pub name: String,
     pub is_primary: bool,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -3,11 +3,14 @@ pub mod property;
 use crate::{XHandle, XrandrError};
 use indexmap::IndexMap;
 use property::{Property, PropertyValue};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 use std::os::raw::c_int;
 use std::{ptr, slice};
 use x11::{xlib, xrandr};
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Output {
     pub xid: u64,
     pub name: String,

--- a/src/output/property.rs
+++ b/src/output/property.rs
@@ -4,8 +4,11 @@ use std::{ptr, slice};
 use x11::{xlib, xrandr};
 
 use crate::{atom_name, real_bool, HandleSys, XHandle, XrandrError};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Property {
     pub name: String,
     pub value: PropertyValue,
@@ -214,6 +217,7 @@ impl From<i32> for ValueFormat {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum PropertyValue {
     Edid(Vec<u8>),
     Guid([u8; 16]),
@@ -281,6 +285,7 @@ impl PropertyValue {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum PropertyValues {
     Range(Ranges),
     Supported(Supported),
@@ -309,6 +314,7 @@ impl From<Supported> for PropertyValues {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Ranges {
     Atom(Vec<Range<String>>),
     Integer8(Vec<Range<i8>>),
@@ -320,6 +326,7 @@ pub enum Ranges {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Range<T> {
     pub lower: T,
     pub upper: T,
@@ -385,6 +392,7 @@ impl Ranges {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Supported {
     Atom(Vec<String>),
     Integer8(Vec<i8>),


### PR DESCRIPTION
To be fair, deserialize is probably not necessary. I haven't yet found an application for this. But in a project I'm working on, I'd like to be able to print the entire monitor setup as json which is now possible (when the feature flag is enabled). If you don't like Deserialize being there too, I'll remove it but I don't think it can hurt.

