### PR TITLE
Fix serialize feature broken by a previous PR.

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,6 +1,9 @@
 use core::ptr;
 use std::slice;
 use x11::xrandr;
+#[cfg(feature= "serialize")]
+use serde::{Deserialize, Serialize};
+
 use crate::XHandle;
 use crate::XrandrError;
 use crate::output::Output;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -7,6 +7,8 @@ use property::{Property, Value};
 use std::os::raw::c_int;
 use std::{ptr, slice};
 use x11::{xlib, xrandr};
+#[cfg(feature= "serialize")]
+use serde::{Deserialize, Serialize};
 
 use crate::CURRENT_TIME;
 use crate::XTime;

--- a/src/output/property.rs
+++ b/src/output/property.rs
@@ -2,6 +2,8 @@ use std::convert::TryInto;
 use std::{ptr, slice};
 
 use x11::{xlib, xrandr};
+#[cfg(feature= "serialize")]
+use serde::{Deserialize, Serialize};
 
 use crate::{atom_name, real_bool, HandleSys, XHandle, XrandrError};
 


### PR DESCRIPTION
I decided to give this crate a go for a pet project today.
I enabled the serialize feature on Cargo.toml and got the following error about a dozen times.

```
error: cannot find derive macro `Serialize` in this scope
   --> src/output/property.rs:428:42
    |
428 | #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
    |                                          ^^^^^^^^^
    |
    = help: consider importing this derive macro:
            serde::Serialize
```

Checked the PR related to the addition of the feature, and the code seemed okay. So I checked the commits after that one, and it appears that the changes that broke this feature are part of #8.

This PR will fix the issue, allowing for the usage of serialize feature.

May I suggest, in the future, to run `cargo build --all-features` or setting up a way to do this, such as using rust-analyzer which pointed me directly to the fact that there were no imports for Deserialize/Serialize.
