### PR TITLE
cargo fmt and change to doc strings

### DIFF
--- a/src/mode.rs
+++ b/src/mode.rs
@@ -6,9 +6,9 @@ use crate::XId;
 const RR_INTERLACE: u64 = 0x0000_0010;
 const RR_DOUBLE_SCAN: u64 = 0x0000_0020;
 
-// Modes correspond to the various display configurations the outputs 
+// Modes correspond to the various display configurations the outputs
 // connected to your machine are capable of displaying. This mostly comes
-// down to resolution/refresh rates, but the `flags` field in particular 
+// down to resolution/refresh rates, but the `flags` field in particular
 // also encodes whether this mode is interlaced/doublescan
 #[derive(Debug, Clone)]
 pub struct Mode {
@@ -28,28 +28,27 @@ pub struct Mode {
     pub rate: f64,
 }
 
-
 impl From<&xrandr::XRRModeInfo> for Mode {
     fn from(x_mode: &xrandr::XRRModeInfo) -> Self {
-        let name_b = unsafe {
-            slice::from_raw_parts(
-                x_mode.name as *const u8,
-                x_mode.nameLength as usize,
-            )
-        };
-    
+        let name_b =
+            unsafe { slice::from_raw_parts(x_mode.name as *const u8, x_mode.nameLength as usize) };
+
         // Calculate the refresh rate for this mode
         // This is not given by xrandr, but tends to be useful for end-users
-        assert!(x_mode.hTotal != 0 && x_mode.vTotal != 0,
-            "Framerate calculation would divide by zero");
+        assert!(
+            x_mode.hTotal != 0 && x_mode.vTotal != 0,
+            "Framerate calculation would divide by zero"
+        );
 
-        let v_total = 
-            if x_mode.modeFlags & RR_DOUBLE_SCAN != 0 { x_mode.vTotal * 2 }
-            else if x_mode.modeFlags & RR_INTERLACE != 0 { x_mode.vTotal / 2 }
-            else { x_mode.vTotal };
+        let v_total = if x_mode.modeFlags & RR_DOUBLE_SCAN != 0 {
+            x_mode.vTotal * 2
+        } else if x_mode.modeFlags & RR_INTERLACE != 0 {
+            x_mode.vTotal / 2
+        } else {
+            x_mode.vTotal
+        };
 
-        let rate = x_mode.dotClock as f64 / 
-            (f64::from(x_mode.hTotal) * f64::from(v_total));
+        let rate = x_mode.dotClock as f64 / (f64::from(x_mode.hTotal) * f64::from(v_total));
 
         Self {
             xid: x_mode.id,
@@ -69,4 +68,3 @@ impl From<&xrandr::XRRModeInfo> for Mode {
         }
     }
 }
-

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,7 +1,7 @@
 use core::ptr;
 use std::slice;
 use x11::xrandr;
-#[cfg(feature= "serialize")]
+#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 use crate::XHandle;
@@ -16,35 +16,23 @@ pub(crate) struct MonitorHandle {
 }
 
 impl MonitorHandle {
-    pub(crate) fn new(handle: &mut XHandle) -> Result<Self,XrandrError> {
+    pub(crate) fn new(handle: &mut XHandle) -> Result<Self, XrandrError> {
         let mut count = 0;
 
-        let raw_ptr = unsafe {
-            xrandr::XRRGetMonitors(
-                handle.sys.as_ptr(),
-                handle.root(),
-                0,
-                &mut count,
-            )
-        };
-        
+        let raw_ptr =
+            unsafe { xrandr::XRRGetMonitors(handle.sys.as_ptr(), handle.root(), 0, &mut count) };
+
         if count == -1 {
             return Err(XrandrError::GetMonitors);
         }
-        
-        let ptr = ptr::NonNull::new(raw_ptr)
-            .ok_or(XrandrError::GetMonitors)?;
+
+        let ptr = ptr::NonNull::new(raw_ptr).ok_or(XrandrError::GetMonitors)?;
 
         Ok(Self { ptr, count })
     }
 
     pub(crate) fn as_slice(&self) -> &[xrandr::XRRMonitorInfo] {
-        unsafe { 
-            slice::from_raw_parts_mut(
-                self.ptr.as_ptr(), 
-                self.count as usize
-            )
-        }
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.count as usize) }
     }
 }
 
@@ -70,4 +58,3 @@ pub struct Monitor {
     /// can have more than one output.
     pub outputs: Vec<Output>,
 }
-

--- a/src/output/property.rs
+++ b/src/output/property.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::{ptr, slice};
 
 use x11::{xlib, xrandr};
-#[cfg(feature= "serialize")]
+#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 use crate::{atom_name, real_bool, HandleSys, XHandle, XrandrError};
@@ -58,14 +58,7 @@ impl Property {
         let format = format.into();
         let value_type: ValueType = value_type.into();
 
-        let value = Self::get_value(
-            &mut handle.sys,
-            &name,
-            value_type,
-            format,
-            items_len,
-            prop,
-        )?;
+        let value = Self::get_value(&mut handle.sys, &name, value_type, format, items_len, prop)?;
 
         let info = unsafe {
             ptr::NonNull::new(xrandr::XRRQueryOutputProperty(
@@ -79,13 +72,12 @@ impl Property {
         let is_immutable = unsafe { real_bool(info.as_ref().immutable) };
         let is_pending = unsafe { real_bool(info.as_ref().pending) };
 
-        let values = unsafe {
-            Self::get_values(&mut handle.sys, info.as_ref(), value_type, format)?
-        };
+        let values =
+            unsafe { Self::get_values(&mut handle.sys, info.as_ref(), value_type, format)? };
 
-        unsafe { 
+        unsafe {
             xlib::XFree(info.as_ptr().cast());
-            xlib::XFree(prop.cast()) 
+            xlib::XFree(prop.cast())
         };
 
         Ok(Self {
@@ -123,9 +115,7 @@ impl Property {
                 ValueFormat::B16 => Value::from_c16(data, len),
                 ValueFormat::B32 => Value::from_c32(data, len),
             },
-            ValueType::Unrecognized(type_sys) => {
-                Value::unrecognized(type_sys, format)
-            }
+            ValueType::Unrecognized(type_sys) => Value::unrecognized(type_sys, format),
         };
 
         Ok(value)
@@ -138,14 +128,10 @@ impl Property {
         format: ValueFormat,
     ) -> Result<Option<Values>, XrandrError> {
         let values = if info.num_values > 0 {
-            let values = unsafe {
-                slice::from_raw_parts(info.values, info.num_values as usize)
-            };
+            let values = unsafe { slice::from_raw_parts(info.values, info.num_values as usize) };
             let values = if real_bool(info.range) {
                 match value_type {
-                    ValueType::Atom => {
-                        Ranges::from_atom(handle, values)?.into()
-                    }
+                    ValueType::Atom => Ranges::from_atom(handle, values)?.into(),
 
                     ValueType::Int => match format {
                         ValueFormat::B8 => Ranges::from_i8(values).into(),
@@ -159,15 +145,11 @@ impl Property {
                         ValueFormat::B32 => Ranges::from_c32(values).into(),
                     },
 
-                    ValueType::Unrecognized(type_sys) => {
-                        Values::unrecognized(type_sys, format)
-                    }
+                    ValueType::Unrecognized(type_sys) => Values::unrecognized(type_sys, format),
                 }
             } else {
                 match value_type {
-                    ValueType::Atom => {
-                        Supported::from_atom(handle, values)?.into()
-                    }
+                    ValueType::Atom => Supported::from_atom(handle, values)?.into(),
 
                     ValueType::Int => match format {
                         ValueFormat::B8 => Supported::from_i8(values).into(),
@@ -181,9 +163,7 @@ impl Property {
                         ValueFormat::B32 => Supported::from_c32(values).into(),
                     },
 
-                    ValueType::Unrecognized(type_sys) => {
-                        Values::unrecognized(type_sys, format)
-                    }
+                    ValueType::Unrecognized(type_sys) => Values::unrecognized(type_sys, format),
                 }
             };
             Some(values)
@@ -274,10 +254,7 @@ impl Value {
         Self::Guid(guid)
     }
 
-    fn from_atom(
-        handle: &mut HandleSys,
-        data: *const u8,
-    ) -> Result<Self, XrandrError> {
+    fn from_atom(handle: &mut HandleSys, data: *const u8) -> Result<Self, XrandrError> {
         // REMOVED: this cast is undefined behaviour
         // let data = unsafe { *(data.cast::<xlib::Atom>()) };
         let data = unsafe { u64::from(*data) };
@@ -363,20 +340,15 @@ pub struct Range<T> {
 }
 
 impl Ranges {
-    fn from_atom(
-        handle: &mut HandleSys,
-        values: &[i64],
-    ) -> Result<Self, XrandrError> {
+    fn from_atom(handle: &mut HandleSys, values: &[i64]) -> Result<Self, XrandrError> {
         let values = values
             .chunks_exact(2)
             .map(|values| {
                 let lower = values[0];
                 let upper = values[1];
 
-                let lower =
-                    unsafe { *(lower as *const i64).cast::<xlib::Atom>() };
-                let upper =
-                    unsafe { *(upper as *const i64).cast::<xlib::Atom>() };
+                let lower = unsafe { *(lower as *const i64).cast::<xlib::Atom>() };
+                let upper = unsafe { *(upper as *const i64).cast::<xlib::Atom>() };
 
                 let lower = atom_name(handle, lower)?;
                 let upper = atom_name(handle, upper)?;
@@ -439,15 +411,11 @@ pub enum Supported {
 }
 
 impl Supported {
-    fn from_atom(
-        handle: &mut HandleSys,
-        values: &[i64],
-    ) -> Result<Self, XrandrError> {
+    fn from_atom(handle: &mut HandleSys, values: &[i64]) -> Result<Self, XrandrError> {
         let values = values
             .iter()
             .map(|val| {
-                let val = 
-                    unsafe { *((val as *const i64).cast::<xlib::Atom>()) };
+                let val = unsafe { *((val as *const i64).cast::<xlib::Atom>()) };
                 let val = atom_name(handle, val)?;
                 Ok(val)
             })

--- a/src/screen_resources.rs
+++ b/src/screen_resources.rs
@@ -10,18 +10,15 @@ use crate::XrandrError;
 use crate::XId;
 use crate::XTime;
 
-
 // A wrapper that drops the pointer if it goes out of scope.
 // Avoid having to deal with the various early returns
 pub(crate) struct ScreenResourcesHandle {
-    ptr: ptr::NonNull<xrandr::XRRScreenResources>
+    ptr: ptr::NonNull<xrandr::XRRScreenResources>,
 }
 
 impl ScreenResourcesHandle {
     pub(crate) fn new(handle: &mut XHandle) -> Result<Self, XrandrError> {
-        let raw_ptr = unsafe { 
-            xrandr::XRRGetScreenResources(handle.sys.as_ptr(), handle.root())
-        };
+        let raw_ptr = unsafe { xrandr::XRRGetScreenResources(handle.sys.as_ptr(), handle.root()) };
 
         let ptr = ptr::NonNull::new(raw_ptr).ok_or(XrandrError::GetResources)?;
         Ok(Self { ptr })
@@ -38,7 +35,6 @@ impl Drop for ScreenResourcesHandle {
     }
 }
 
-
 #[derive(Debug)]
 pub struct ScreenResources {
     pub timestamp: XTime,
@@ -49,7 +45,6 @@ pub struct ScreenResources {
     pub nmode: i32,
     pub modes: Vec<Mode>,
 }
-
 
 impl ScreenResources {
     /// Create a handle to the `XRRScreenResources` object from libxrandr.
@@ -65,39 +60,38 @@ impl ScreenResources {
     /// let crtc_87 = res.crtc(&mut xhandle, 87);
     /// ```
     ///
-    pub fn new(handle: &mut XHandle) 
-    -> Result<ScreenResources, XrandrError> 
-    {
+    pub fn new(handle: &mut XHandle) -> Result<ScreenResources, XrandrError> {
         // TODO: does this need to be freed?
         let res = ScreenResourcesHandle::new(handle)?;
         let xrandr::XRRScreenResources {
-            modes, nmode, 
-            crtcs, ncrtc, 
-            outputs, noutput, 
-            timestamp, configTimestamp, ..
+            modes,
+            nmode,
+            crtcs,
+            ncrtc,
+            outputs,
+            noutput,
+            timestamp,
+            configTimestamp,
+            ..
         } = unsafe { res.ptr.as_ref() };
 
-        let x_modes: &[xrandr::XRRModeInfo] = unsafe { 
-            slice::from_raw_parts(*modes, *nmode as usize) };
+        let x_modes: &[xrandr::XRRModeInfo] =
+            unsafe { slice::from_raw_parts(*modes, *nmode as usize) };
 
-        let modes: Vec<Mode> = x_modes.iter()
-            .map(Mode::from)
-            .collect();
+        let modes: Vec<Mode> = x_modes.iter().map(Mode::from).collect();
 
-        let x_crtcs = unsafe { 
-            slice::from_raw_parts(*crtcs, *ncrtc as usize) };
+        let x_crtcs = unsafe { slice::from_raw_parts(*crtcs, *ncrtc as usize) };
 
-        let x_outputs = unsafe { 
-            slice::from_raw_parts(*outputs, *noutput as usize) };
+        let x_outputs = unsafe { slice::from_raw_parts(*outputs, *noutput as usize) };
 
-        Ok(ScreenResources { 
+        Ok(ScreenResources {
             timestamp: *timestamp,
             config_timestamp: *configTimestamp,
             ncrtc: *ncrtc,
             crtcs: x_crtcs.to_vec(),
             outputs: x_outputs.to_vec(),
             nmode: *nmode,
-            modes
+            modes,
         })
     }
 
@@ -113,10 +107,9 @@ impl ScreenResources {
     /// let outputs = res.outputs(&mut xhandle);
     /// ```
     ///
-    pub fn outputs(&self, handle: &mut XHandle)
-    -> Result<Vec<Output>, XrandrError> 
-    {
-        self.outputs.iter()
+    pub fn outputs(&self, handle: &mut XHandle) -> Result<Vec<Output>, XrandrError> {
+        self.outputs
+            .iter()
             .map(|xid| Output::from_xid(handle, *xid))
             .collect()
     }
@@ -133,10 +126,9 @@ impl ScreenResources {
     /// let output_89 = res.output(&mut xhandle, 89);
     /// ```
     ///
-    pub fn output(&self, handle: &mut XHandle, xid: XId)
-    -> Result<Output, XrandrError> 
-    {
-        self.outputs(handle)?.into_iter()
+    pub fn output(&self, handle: &mut XHandle, xid: XId) -> Result<Output, XrandrError> {
+        self.outputs(handle)?
+            .into_iter()
             .find(|o| o.xid == xid)
             .ok_or(XrandrError::GetOutputInfo(xid))
     }
@@ -153,10 +145,9 @@ impl ScreenResources {
     /// let crtcs = res.crtcs(&mut xhandle);
     /// ```
     ///
-    pub fn crtcs(&self, handle: &mut XHandle) 
-    -> Result<Vec<Crtc>, XrandrError> 
-    {
-        self.crtcs.iter()
+    pub fn crtcs(&self, handle: &mut XHandle) -> Result<Vec<Crtc>, XrandrError> {
+        self.crtcs
+            .iter()
             .map(|xid| Crtc::from_xid(handle, *xid))
             .collect()
     }
@@ -167,10 +158,10 @@ impl ScreenResources {
     /// * `XrandrError::GetCrtcInfo(xid)`
     ///    -- Getting info failed for crtc with XID `xid`
     ///
-    pub fn enabled_crtcs(&self, handle: &mut XHandle) 
-    -> Result<Vec<Crtc>, XrandrError> 
-    {
-        Ok(self.crtcs(handle)?.into_iter()
+    pub fn enabled_crtcs(&self, handle: &mut XHandle) -> Result<Vec<Crtc>, XrandrError> {
+        Ok(self
+            .crtcs(handle)?
+            .into_iter()
             .filter(|c| c.mode != 0)
             .collect())
     }
@@ -187,14 +178,12 @@ impl ScreenResources {
     /// let current_crtc = res.crtc(&mut xhandle, output.crtc);
     /// ```
     ///
-    pub fn crtc(&self, handle: &mut XHandle, xid: XId) 
-    -> Result<Crtc, XrandrError> 
-    {
-        self.crtcs(handle)?.into_iter()
+    pub fn crtc(&self, handle: &mut XHandle, xid: XId) -> Result<Crtc, XrandrError> {
+        self.crtcs(handle)?
+            .into_iter()
             .find(|c| c.xid == xid)
             .ok_or(XrandrError::GetCrtc(xid))
     }
-
 
     /// Gets information on all crtcs
     ///
@@ -208,7 +197,8 @@ impl ScreenResources {
     /// let crtcs = res.crtcs(&mut xhandle);
     /// ```
     ///
-    #[must_use] pub fn modes(&self) -> Vec<Mode> {
+    #[must_use]
+    pub fn modes(&self) -> Vec<Mode> {
         self.modes.clone()
     }
 
@@ -225,11 +215,10 @@ impl ScreenResources {
     /// ```
     ///
     pub fn mode(&self, xid: XId) -> Result<Mode, XrandrError> {
-        self.modes.iter()
+        self.modes
+            .iter()
             .find(|c| c.xid == xid)
             .cloned()
             .ok_or(XrandrError::GetModeInfo(xid))
     }
-
 }
-

--- a/src/screensize.rs
+++ b/src/screensize.rs
@@ -14,52 +14,49 @@ pub struct ScreenSize {
 }
 
 // Apparently this does not exist (in non-nightly)?
-// This function checks the requirements for a safe cast (right?), 
+// This function checks the requirements for a safe cast (right?),
 // so we allow possible trunction here and only here
 #[allow(clippy::cast_possible_truncation)]
 fn lossy_f32_to_i32(from: f32) -> Result<i32, ()> {
-    if from.round() >= i32::MIN as f32 && from.round() <= i32::MAX as f32  {
+    if from.round() >= i32::MIN as f32 && from.round() <= i32::MAX as f32 {
         Ok(from.round() as i32)
+    } else {
+        Err(())
     }
-    else { Err(()) }
 }
 
 impl ScreenSize {
     /// True iff the given crtc fits on a screen of this size
-    #[must_use] pub fn fits_crtc(&self, crtc: &Crtc) -> bool {
+    #[must_use]
+    pub fn fits_crtc(&self, crtc: &Crtc) -> bool {
         let (max_x, max_y) = crtc.max_coordinates();
         max_x <= self.width && max_y <= self.height
     }
 
     /// Calculates the screen size that (snugly) fits a set of crtcs
-    pub(crate) fn fitting_crtcs(
-        handle: &mut XHandle, crtcs: &[Crtc]) 
-    -> Self 
-    {
+    pub(crate) fn fitting_crtcs(handle: &mut XHandle, crtcs: &[Crtc]) -> Self {
         // see also: following unwraps
         assert!(!crtcs.is_empty(), "Empty input vector");
 
-        let width = crtcs.iter()
-            .map(|p| p.max_coordinates().0)
-            .max()
-            .unwrap();
-        let height = crtcs.iter()
-            .map(|p| p.max_coordinates().1)
-            .max()
-            .unwrap();
+        let width = crtcs.iter().map(|p| p.max_coordinates().0).max().unwrap();
+        let height = crtcs.iter().map(|p| p.max_coordinates().1).max().unwrap();
 
         // Get the old sizes to calculate the dpi
         let c_h = unsafe { xlib::XDisplayHeight(handle.sys.as_ptr(), 0) };
         let c_h_mm = unsafe { xlib::XDisplayHeightMM(handle.sys.as_ptr(), 0) };
-        
+
         // Calculate the new physical size with the dpi and px count
         let dpi: f32 = (INCH_MM * c_h as f32) / c_h_mm as f32;
 
         // let x = (INCH_MM * width as f32) / dpi
         let width_mm = lossy_f32_to_i32((INCH_MM * width as f32) / dpi).unwrap();
-		let height_mm = lossy_f32_to_i32((INCH_MM * height as f32) / dpi).unwrap();
+        let height_mm = lossy_f32_to_i32((INCH_MM * height as f32) / dpi).unwrap();
 
-        ScreenSize{ width, width_mm, height, height_mm }
+        ScreenSize {
+            width,
+            width_mm,
+            height,
+            height_mm,
+        }
     }
 }
-


### PR DESCRIPTION
There was a rustdoc inaccuracy i noticed when i tried to use this crate. I changed the docstring to be correct and ran `cargo fmt`

Specifically, I changed the example for Xhandle.open to correctly use
```rs
let xhandle = XHandle::open()?;
```
instead of incorrectly using
```rs
let xhandle = XHandle.open()?;
```