### PR TITLE
Applying size in SetMode()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
+use itertools::EitherOrBoth as ZipEntry;
+use itertools::Itertools;
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt::Debug;
 use std::os::raw::c_ulong;
 use std::ptr;
-use itertools::Itertools;
-use itertools::EitherOrBoth as ZipEntry;
 
 use crtc::normalize_positions;
 pub use indexmap;
@@ -13,13 +13,13 @@ use thiserror::Error;
 use x11::{xlib, xrandr};
 
 pub use crate::crtc::Crtc;
-pub use crate::crtc::{Rotation, Relation};
+pub use crate::crtc::{Relation, Rotation};
 pub use crate::mode::Mode;
-pub use crate::screensize::ScreenSize;
 pub use crate::monitor::Monitor;
 use crate::monitor::MonitorHandle;
+pub use crate::screensize::ScreenSize;
 pub use output::{
-    property::{Property, Value, Values, Range, Ranges, Supported},
+    property::{Property, Range, Ranges, Supported, Value, Values},
     Output,
 };
 
@@ -233,6 +233,8 @@ impl XHandle {
         let mut crtc = ScreenResources::new(self)?.crtc(self, crtc_id)?;
 
         crtc.mode = mode.xid;
+        crtc.height = mode.height;
+        crtc.width = mode.width;
         self.apply_new_crtcs(&mut [crtc])
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
-use itertools::EitherOrBoth as ZipEntry;
-use itertools::Itertools;
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt::Debug;
 use std::os::raw::c_ulong;
 use std::ptr;
+use itertools::EitherOrBoth as ZipEntry;
+use itertools::Itertools;
 
 use crtc::normalize_positions;
 pub use indexmap;
@@ -15,11 +15,11 @@ use x11::{xlib, xrandr};
 pub use crate::crtc::Crtc;
 pub use crate::crtc::{Relation, Rotation};
 pub use crate::mode::Mode;
+pub use crate::screensize::ScreenSize;
 pub use crate::monitor::Monitor;
 use crate::monitor::MonitorHandle;
-pub use crate::screensize::ScreenSize;
 pub use output::{
-    property::{Property, Range, Ranges, Supported, Value, Values},
+    property::{Property, Value, Values, Range, Ranges, Supported},
     Output,
 };
 
@@ -233,6 +233,7 @@ impl XHandle {
         let mut crtc = ScreenResources::new(self)?.crtc(self, crtc_id)?;
 
         crtc.mode = mode.xid;
+        //Width and Height required by apply_new_crtcs to recalculate ScreenSize in fitting_crtcs
         crtc.height = mode.height;
         crtc.width = mode.width;
         self.apply_new_crtcs(&mut [crtc])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ use std::ffi::CStr;
 use std::fmt::Debug;
 use std::os::raw::c_ulong;
 use std::ptr;
-use itertools::EitherOrBoth as ZipEntry;
 use itertools::Itertools;
+use itertools::EitherOrBoth as ZipEntry;
 
 use crtc::normalize_positions;
 pub use indexmap;
@@ -13,7 +13,7 @@ use thiserror::Error;
 use x11::{xlib, xrandr};
 
 pub use crate::crtc::Crtc;
-pub use crate::crtc::{Relation, Rotation};
+pub use crate::crtc::{Rotation, Relation};
 pub use crate::mode::Mode;
 pub use crate::screensize::ScreenSize;
 pub use crate::monitor::Monitor;


### PR DESCRIPTION
SetMode does not utilize the Mode's new width and height to change the new crtc. This leads the apply_new_crtcs to silently fail fits_crtc and not apply the change to resolution if it increases the ScreenSize.